### PR TITLE
Add panel for country relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ src/
     Map.jsx
     NodeTooltip.jsx
     CountrySidePanel.jsx
+    CountryRelationshipsPanel.jsx
     ArticleForm.jsx
     RelationshipMap.jsx
     SidePanel.jsx

--- a/src/components/CountryRelationshipsPanel.jsx
+++ b/src/components/CountryRelationshipsPanel.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+export default function CountryRelationshipsPanel({ country, relationships }) {
+  const style = {
+    width: '25%',
+    padding: '1rem',
+    borderLeft: '1px solid #ccc',
+    transform: country ? 'translateX(0)' : 'translateX(100%)',
+    transition: 'transform 0.3s ease-in-out',
+  };
+
+  if (!country) {
+    return <aside style={style}>Select a country</aside>;
+  }
+
+  const rels = relationships.filter(
+    (r) => r.source === country || r.target === country
+  );
+
+  return (
+    <aside style={style}>
+      <h2>{country}</h2>
+      {rels.length === 0 ? (
+        <p>No relationships found</p>
+      ) : (
+        <ul style={{ listStyle: 'none', padding: 0 }}>
+          {rels.map((rel, idx) => {
+            const partner = rel.source === country ? rel.target : rel.source;
+            return (
+              <li key={idx} style={{ marginBottom: '1rem' }}>
+                <strong>{partner}</strong>
+                <div>Type: {rel.type}</div>
+                <div>Justification: {rel.justification}</div>
+                <div>Tags: {rel.tags.join(', ')}</div>
+              </li>
+            );
+          })
+        </ul>
+      )}
+    </aside>
+  );
+}

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -7,7 +7,7 @@ import { relationColor } from '../utils/colorUtils';
 const width = 960;
 const height = 500;
 
-export default function Map() {
+export default function Map({ onCountrySelect }) {
   const svgRef = useRef(null);
   const [relations, setRelations] = useState([]);
   const [selected, setSelected] = useState(null);
@@ -53,7 +53,10 @@ export default function Map() {
         .attr('cx', x)
         .attr('cy', y)
         .attr('r', 2)
-        .attr('fill', 'black');
+        .attr('fill', 'black')
+        .on('click', () => {
+          if (onCountrySelect) onCountrySelect(country.properties.name);
+        });
     });
 
     const lineGenerator = d3.linkHorizontal()

--- a/src/pages/BusinessView.jsx
+++ b/src/pages/BusinessView.jsx
@@ -1,7 +1,7 @@
 import Head from 'next/head';
 import Map from '../components/Map';
-import CountrySidePanel from '../components/CountrySidePanel';
-import countryMeta from '../data/countryMeta.json';
+import CountryRelationshipsPanel from '../components/CountryRelationshipsPanel';
+import relationships from '../data/relationships.json';
 import { useState } from 'react';
 
 export default function BusinessView() {
@@ -14,9 +14,9 @@ export default function BusinessView() {
       </Head>
       <main style={{ flexGrow: 1 }}>
         <h1>Business View</h1>
-        <Map />
+        <Map onCountrySelect={setSelected} />
       </main>
-      <CountrySidePanel country={selected || countryMeta[0]} />
+      <CountryRelationshipsPanel country={selected} relationships={relationships} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- expose country selection in Map component
- show selected country's relationships in a new sliding panel
- use the new panel in BusinessView
- document the CountryRelationshipsPanel component

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853dc24215c8333b88fab7c9150d5f0