### PR TITLE
Add close button to CountrySidePanel

### DIFF
--- a/src/components/CountrySidePanel.jsx
+++ b/src/components/CountrySidePanel.jsx
@@ -1,10 +1,25 @@
 import React from 'react';
 
-export default function CountrySidePanel({ country }) {
-  if (!country) return <aside style={{ width: '20%', padding: '1rem' }}>Select a country</aside>;
+export default function CountrySidePanel({ country, onClose }) {
+  if (!country)
+    return <aside style={{ width: '20%', padding: '1rem' }}>Select a country</aside>;
+
   return (
     <aside style={{ width: '20%', padding: '1rem', borderLeft: '1px solid #ccc' }}>
-      <h2>{country.name}</h2>
+      <header
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <h2 style={{ margin: 0 }}>{country.name}</h2>
+        {onClose && (
+          <button onClick={onClose} aria-label="Close panel">
+            ×
+          </button>
+        )}
+      </header>
       <p>Code: {country.code}</p>
     </aside>
   );

--- a/src/pages/BusinessView.jsx
+++ b/src/pages/BusinessView.jsx
@@ -16,7 +16,10 @@ export default function BusinessView() {
         <h1>Business View</h1>
         <Map onCountrySelect={setSelected} />
       </main>
-      <CountrySidePanel country={selected || countryMeta[0]} />
+      <CountrySidePanel
+        country={selected || countryMeta[0]}
+        onClose={() => setSelected(null)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add an `onClose` prop to `CountrySidePanel` and render a close button in the header
- call `onClose` from `BusinessView` when closing the panel

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593d43ce28833380b0a923f54db51f