### PR TITLE
Add country relationship side panel

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -7,7 +7,7 @@ import { relationColor } from '../utils/colorUtils';
 const width = 960;
 const height = 500;
 
-export default function Map({ onCountrySelect }) {
+export default function Map({ onSelectCountry }) {
   const svgRef = useRef(null);
   const [relations, setRelations] = useState([]);
   const [selected, setSelected] = useState(null);
@@ -55,7 +55,7 @@ export default function Map({ onCountrySelect }) {
         .attr('r', 2)
         .attr('fill', 'black')
         .on('click', () => {
-          if (onCountrySelect) onCountrySelect(country.properties.name);
+          if (onSelectCountry) onSelectCountry(country.properties.name);
         });
     });
 

--- a/src/components/RelationshipMap.jsx
+++ b/src/components/RelationshipMap.jsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from 'react';
 import * as d3 from 'd3';
 import relationships from '../data/relationships.json';
 import { relationColor } from '../utils/colorUtils';
-import SidePanel from './SidePanel';
 import FilterPanel from './FilterPanel';
 
 const width = 600;
@@ -10,7 +9,6 @@ const height = 400;
 
 export default function RelationshipMap() {
   const svgRef = useRef(null);
-  const [selected, setSelected] = useState(null);
   const [filters, setFilters] = useState({
     showAlliance: true,
     showConflict: true,
@@ -82,8 +80,7 @@ export default function RelationshipMap() {
           (d.source.id && d.source.id === h) ||
           (d.target.id && d.target.id === h);
         return involves ? 1 : 0.3;
-      })
-      .on('click', (event, d) => setSelected(d));
+      });
 
     const node = svg
       .append('g')
@@ -100,11 +97,7 @@ export default function RelationshipMap() {
           .on('start', dragstarted)
           .on('drag', dragged)
           .on('end', dragended)
-      )
-      .on('click', (event, d) => {
-        const rel = relationships.find(r => r.source === d.id || r.target === d.id);
-        setSelected(rel);
-      });
+      );
 
     const label = svg
       .append('g')
@@ -159,7 +152,6 @@ export default function RelationshipMap() {
   return (
     <div style={{ position: 'relative', display: 'flex' }}>
       <svg ref={svgRef} width={width} height={height} />
-      <SidePanel relation={selected} />
       <FilterPanel filters={filters} setFilters={setFilters} />
     </div>
   );

--- a/src/components/SidePanel.jsx
+++ b/src/components/SidePanel.jsx
@@ -1,33 +1,63 @@
 import React from 'react';
 
-export default function SidePanel({ relation }) {
+export default function SidePanel({ selectedCountry, relations = [], onClose }) {
   const style = {
     width: '25%',
     padding: '1rem',
     borderLeft: '1px solid #ccc',
-    transform: relation ? 'translateX(0)' : 'translateX(100%)',
+    transform: selectedCountry ? 'translateX(0)' : 'translateX(100%)',
     transition: 'transform 0.3s ease-in-out',
   };
 
-  if (!relation) {
-    return <aside style={style}>Select a relationship</aside>;
+  if (!selectedCountry) {
+    return <aside style={style}>Select a country</aside>;
   }
+
+  const matches = relations.filter(
+    (r) => r.source === selectedCountry || r.target === selectedCountry
+  );
 
   return (
     <aside style={style}>
-      <h2>{relation.source} → {relation.target}</h2>
-      <p>Type: {relation.type}</p>
-      <p>Justification: {relation.justification}</p>
-      <p>Tags: {relation.tags.join(', ')}</p>
-      <div>
-        {relation.sources.map((url) => (
-          <div key={url}>
-            <a href={url} target="_blank" rel="noopener noreferrer">
-              {url}
-            </a>
-          </div>
-        ))}
-      </div>
+      <header
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <h2 style={{ margin: 0 }}>{selectedCountry}</h2>
+        {onClose && (
+          <button onClick={onClose} aria-label="Close panel">
+            ×
+          </button>
+        )}
+      </header>
+      {matches.length === 0 ? (
+        <p>No relationships found</p>
+      ) : (
+        <ul style={{ listStyle: 'none', padding: 0 }}>
+          {matches.map((rel, idx) => (
+            <li key={idx} style={{ marginBottom: '1rem' }}>
+              <strong>
+                {rel.source === selectedCountry ? rel.target : rel.source}
+              </strong>{' '}
+              - {rel.type}
+              <div>Justification: {rel.justification}</div>
+              <div>Tags: {rel.tags.join(', ')}</div>
+              <div>
+                {rel.sources.map((url) => (
+                  <div key={url}>
+                    <a href={url} target="_blank" rel="noopener noreferrer">
+                      {url}
+                    </a>
+                  </div>
+                ))}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
     </aside>
   );
 }

--- a/src/pages/BusinessView.jsx
+++ b/src/pages/BusinessView.jsx
@@ -14,7 +14,7 @@ export default function BusinessView() {
       </Head>
       <main style={{ flexGrow: 1 }}>
         <h1>Business View</h1>
-        <Map onCountrySelect={setSelected} />
+        <Map onSelectCountry={setSelected} />
       </main>
       <CountrySidePanel
         country={selected || countryMeta[0]}

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,5 +1,14 @@
 import '../styles/globals.css';
+import { useState } from 'react';
 
 export default function App({ Component, pageProps }) {
-  return <Component {...pageProps} />;
+  const [selectedCountry, setSelectedCountry] = useState(null);
+
+  return (
+    <Component
+      {...pageProps}
+      selectedCountry={selectedCountry}
+      setSelectedCountry={setSelectedCountry}
+    />
+  );
 }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,21 +1,28 @@
 import Head from 'next/head';
 import dynamic from 'next/dynamic';
+import SidePanel from '../components/SidePanel';
+import relationships from '../data/relationships.json';
 
 const Map = dynamic(() => import('../components/Map'), {
   ssr: false,
 });
 
-export default function Home() {
+export default function Home({ selectedCountry, setSelectedCountry }) {
   return (
-    <div>
+    <div style={{ display: 'flex' }}>
       <Head>
         <title>GeoTangle</title>
         <meta name="description" content="Interactive world alliances and conflicts" />
       </Head>
-      <main>
+      <main style={{ flexGrow: 1 }}>
         <h1>GeoTangle</h1>
-        <Map />
+        <Map onSelectCountry={setSelectedCountry} />
       </main>
+      <SidePanel
+        selectedCountry={selectedCountry}
+        relations={relationships}
+        onClose={() => setSelectedCountry(null)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- update `SidePanel` to show relationships for a selected country
- maintain `selectedCountry` state in `_app.js`
- update `Map` component to emit `onSelectCountry`
- show `SidePanel` on the home page
- update BusinessView page to new prop name
- remove old SidePanel usage from RelationshipMap

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593dfc9eb483338b258e7495e6c31b