### PR TITLE
Fix NodeTooltip sources display

### DIFF
--- a/src/components/NodeTooltip.jsx
+++ b/src/components/NodeTooltip.jsx
@@ -8,7 +8,15 @@ export default function NodeTooltip({ relation }) {
       <div>Type: {relation.type}</div>
       <div>{relation.justification}</div>
       <div>
-        Sources: {relation.sources.join(', ')}
+        Sources:{' '}
+        {Array.isArray(relation.sources)
+          ? relation.sources.map((src, idx) => (
+              <span key={idx}>
+                {src}
+                {idx < relation.sources.length - 1 ? ', ' : ''}
+              </span>
+            ))
+          : 'No sources'}
       </div>
       <div>
         Tags: {relation.tags.join(', ')}


### PR DESCRIPTION
## Summary
- guard against missing `relation.sources`

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859830ba0888333921d2a5f85a085df