### PR TITLE
Fix SidePanel CSS module usage

### DIFF
--- a/src/components/SidePanel.jsx
+++ b/src/components/SidePanel.jsx
@@ -10,7 +10,7 @@ function SidePanel({ selectedCountry, onClose, relationships }) {
   );
 
   return (
-    <div className="{styles.sidepanel}">
+    <div className={styles['side-panel']}>
       <button onClick={onClose} className="close-btn">✖</button>
       <h2>{selectedCountry}</h2>
       {filtered.length === 0 ? (
@@ -20,7 +20,7 @@ function SidePanel({ selectedCountry, onClose, relationships }) {
           <div key={i} className="relation-box">
             <strong>{rel.source} ↔ {rel.target}</strong><br />
             Type: {rel.type}<br />
-            <em>{rel.jits}</em><br />
+            <em>{rel.justification}</em><br />
             Tags: {rel.tags.join(', ')}<br />
             <a href={rel.sources[0]} target="_blank" rel="noreferrer">Source</a>
           </div>


### PR DESCRIPTION
## Summary
- use the `side-panel` class from the CSS module correctly
- show relationship justification instead of old `jits` property

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685983cb31ac8333a68e28d155d0075c